### PR TITLE
Removed fields from EggArchiveEntry and mapped props to held IEggArch…

### DIFF
--- a/src/EggDotNet/EggArchive.cs
+++ b/src/EggDotNet/EggArchive.cs
@@ -19,7 +19,8 @@ namespace EggDotNet
 		private bool disposedValue;
 
 		private readonly List<EggArchiveEntry> _entries;
-		private readonly IEggFileFormat format;
+		
+		internal readonly IEggFileFormat format;
 
 		/// <summary>
 		/// Gets the archive-level comment text.

--- a/src/EggDotNet/EggArchiveEntry.cs
+++ b/src/EggDotNet/EggArchiveEntry.cs
@@ -14,9 +14,11 @@ namespace EggDotNet
 	/// </summary>
 	public sealed class EggArchiveEntry
 	{
-		private readonly IEggFileFormat _format;
+		private IEggFileFormat _format => Archive.format;
 
-		internal long PositionInStream { get; set; }
+		internal readonly IEggFileEntry entry;
+		internal long PositionInStream => entry.Position;
+		
 
 		/// <summary>
 		/// Gets the parent <see cref="EggArchive"/> for this entry.
@@ -26,7 +28,7 @@ namespace EggDotNet
 		/// <summary>
 		/// Gets the ID of the egg entry.
 		/// </summary>
-		public int Id { get; internal set; }
+		public int Id => entry.Id;
 
 		/// <summary>
 		/// Gets the name of the egg entry, not including any directory.
@@ -41,64 +43,64 @@ namespace EggDotNet
 		/// Gets the name of the egg entry, including any directory.
 		/// </summary>
 #if NETSTANDARD2_1_OR_GREATER
-		public string? FullName { get; internal set; }
+		public string? FullName => entry.Name;
 #else
-		public string FullName { get; internal set; }
+		public string FullName => entry.Name;
 #endif
 
 		/// <summary>
 		/// Gets the Crc32 checksum for this entry.
 		/// </summary>
-		public uint Crc32 { get; internal set; }
+		public uint Crc32 => entry.Crc32;
 
 		/// <summary>
 		/// Gets a flag indicating whether the entry is encrypted.
 		/// </summary>
-		public bool IsEncrypted { get; internal set; }
+		public bool IsEncrypted => entry.IsEncrypted;
 
 		/// <summary>
 		/// Gets the compressed length of the file.
 		/// </summary>
-		public long CompressedLength { get; internal set; }
+		public long CompressedLength => entry.CompressedSize;
 
 		/// <summary>
 		/// Gets the uncompressed length of the file.
 		/// </summary>
-		public long UncompressedLength { get; internal set; }
+		public long UncompressedLength => entry.UncompressedSize;
 
 		/// <summary>
 		/// Gets the compression method used to compress this entry.
 		/// </summary>
-		public CompressionMethod CompressionMethod { get; internal set; }
+		public CompressionMethod CompressionMethod => entry.CompressionMethod;
 
 		/// <summary>
 		/// Gets the last write time of the file.
 		/// </summary>
 #if NETSTANDARD2_1_OR_GREATER
-		public DateTime? LastWriteTime { get; internal set; }
+		public DateTime? LastWriteTime => entry.LastWriteTime;
 #else
-		public DateTime LastWriteTime { get; internal set; }
+		public DateTime LastWriteTime => entry.LastWriteTime;
 #endif
 
 		/// <summary>
 		/// Gets the external attributes for the entry.
 		/// </summary>
 		/// <remarks>See <see cref="WindowsFileAttributes"/>.</remarks>
-		public long ExternalAttributes {  get; internal set; }
+		public long ExternalAttributes => entry.ExternalAttributes;
 
 		/// <summary>
 		/// Gets the comment of the file.
 		/// </summary>
 #if NETSTANDARD2_1_OR_GREATER
-		public string? Comment { get; internal set; }
+		public string? Comment => entry.Comment;
 #else
-		public string Comment { get; internal set; }
+		public string Comment => entry.Comment;
 #endif
 
-		internal EggArchiveEntry(IEggFileFormat format, EggArchive archive)
+		internal EggArchiveEntry(IEggFileEntry entry, EggArchive archive)
 		{
-			_format = format;
 			Archive = archive;
+			this.entry = entry;
 		}
 
 		/// <summary>

--- a/src/EggDotNet/Extensions/Utilities.cs
+++ b/src/EggDotNet/Extensions/Utilities.cs
@@ -6,11 +6,18 @@ namespace EggDotNet.Extensions
 {
 	internal static class Utilities
 	{
-		private const long MODDATE_EPOCH_TICKS = 504911232000000000;
+		private const long EGG_MODDATE_EPOCH_TICKS = 504911232000000000;
+
+		private const long ALZ_MODDATE_EPOCH_TICKS = 623695183570000000;
 
 		public static DateTime FromEggTime(long timeVal)
 		{
-			return new DateTime(timeVal + MODDATE_EPOCH_TICKS);
+			return new DateTime(timeVal + EGG_MODDATE_EPOCH_TICKS);
+		}
+
+		public static DateTime FromAlzTime(long timeVal)
+		{
+			return new DateTime(timeVal * 10000000L + ALZ_MODDATE_EPOCH_TICKS);
 		}
 	}
 }

--- a/src/EggDotNet/Format/Alz/AlzFormat.cs
+++ b/src/EggDotNet/Format/Alz/AlzFormat.cs
@@ -16,7 +16,7 @@ namespace EggDotNet.Format.Alz
 		{
 			var st = PrepareStream();
 			Stream subSt = new SubStream(st, entry.PositionInStream, entry.PositionInStream + entry.CompressedLength);
-			var eggEntry = _entriesCache.Single(e => e.Id == entry.Id);
+			var eggEntry = (AlzEntry)entry.entry;
 
 			IStreamCompressionProvider streamProvider;
 			if (eggEntry.CompressionMethod == CompressionMethod.Deflate)
@@ -40,9 +40,7 @@ namespace EggDotNet.Format.Alz
 #pragma warning disable CA1859
 		private Stream PrepareStream()
 		{
-			var st = new FakeDisposingStream(_volumes.Single().GetStream());
-
-			return st;
+			return new FakeDisposingStream(_volumes.Single().GetStream());
 		}
 
 		public List<EggArchiveEntry> Scan(EggArchive archive)
@@ -54,7 +52,7 @@ namespace EggDotNet.Format.Alz
 				var ret = new List<EggArchiveEntry>();
 				foreach (var entry in _entriesCache)
 				{
-					ret.Add(entry.ToArchiveEntry(this, archive));
+					ret.Add(new EggArchiveEntry(entry, archive));
 				}
 				return ret;
 			}
@@ -78,8 +76,6 @@ namespace EggDotNet.Format.Alz
 				disposedValue = true;
 			}
 		}
-
-
 
 		public void Dispose()
 		{

--- a/src/EggDotNet/Format/Alz/FileHeader.cs
+++ b/src/EggDotNet/Format/Alz/FileHeader.cs
@@ -23,6 +23,8 @@ namespace EggDotNet.Format.Alz
 
 		public long StartPosition { get; private set; }
 
+		public DateTime LastWriteTime { get; private set; }
+
 		private FileHeader()
 		{
 
@@ -45,7 +47,13 @@ namespace EggDotNet.Format.Alz
 			var header = new FileHeader();
 
 			stream.ReadShort(out short filenameLen);
-			stream.Seek(5, SeekOrigin.Current);
+			stream.ReadByte(out byte attributes);
+			stream.ReadUInt(out uint moddate);
+
+			header.LastWriteTime = Utilities.FromAlzTime(moddate);
+			//header.La = Utilities.FromAlzTime(moddate);
+			
+			//stream.Seek(5, SeekOrigin.Current);
 
 			stream.ReadShort(out short bitFlags);
 

--- a/src/EggDotNet/Format/Egg/EggEntry.cs
+++ b/src/EggDotNet/Format/Egg/EggEntry.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace EggDotNet.Format.Egg
 {
-	internal sealed class EggEntry
+	internal sealed class EggEntry : IEggFileEntry
 	{
 		public int Id { get; private set; }
 		public string Name { get; private set; }
@@ -26,26 +26,17 @@ namespace EggDotNet.Format.Egg
 
 		public string Comment { get; private set; }
 
-		public uint Crc { get; private set; }
+		public uint Crc32 { get; private set; }
 
-		public EggArchiveEntry ToArchiveEntry(EggFormat format, EggArchive archive)
-		{
-			return new EggArchiveEntry(format, archive)
-			{
-				Archive = archive,
-				Comment = Comment,
-				CompressedLength = CompressedSize,
-				CompressionMethod = CompressionMethod,
-				Crc32 = Crc,
-				ExternalAttributes = GetExternalAttributes(),
-				FullName = Name,
-				Id = Id,
-				IsEncrypted = EncryptHeader != null,
-				LastWriteTime = GetLastWriteTime(),
-				PositionInStream = Position,
-				UncompressedLength = UncompressedSize
-			};
-		}
+		public bool IsEncrypted => EncryptHeader != null;
+
+		public long ExternalAttributes => GetExternalAttributes();
+
+#if NETSTANDARD2_1_OR_GREATER
+		public DateTime? LastWriteTime => GetLastWriteTime();
+#else
+		public DateTime LastWriteTime => GetLastWriteTime();
+#endif
 
 		public static List<EggEntry> ParseEntries(Stream stream, EggArchive archive)
 		{
@@ -128,7 +119,7 @@ namespace EggDotNet.Format.Egg
 					entry.CompressedSize = blockHeader.CompressedSize;
 					//entry.UncompressedSize = blockHeader.UncompressedSize; //set by file header
 					entry.CompressionMethod = blockHeader.CompressionMethod;
-					entry.Crc = blockHeader.Crc32;
+					entry.Crc32 = blockHeader.Crc32;
 					stream.Seek(entry.CompressedSize, SeekOrigin.Current);
 					break;
 				}

--- a/src/EggDotNet/Format/Egg/EggFormat.cs
+++ b/src/EggDotNet/Format/Egg/EggFormat.cs
@@ -44,7 +44,7 @@ namespace EggDotNet.Format.Egg
 				var ret = new List<EggArchiveEntry>(_entriesCache.Count);
 				foreach (var entry in _entriesCache)
 				{
-					ret.Add(entry.ToArchiveEntry(this, archive));
+					ret.Add(new EggArchiveEntry(entry, archive));
 				}
 				return ret;
 			}
@@ -54,8 +54,7 @@ namespace EggDotNet.Format.Egg
 		{
 			var st = PrepareStream();
 			Stream subSt = new SubStream(st, entry.PositionInStream, entry.PositionInStream + entry.CompressedLength);
-			var eggEntry = _entriesCache.Single(e => e.Id == entry.Id);
-
+			var eggEntry = (EggEntry)entry.entry;
 			if (eggEntry.EncryptHeader != null)
 			{
 				subSt = GetDecryptionStream(subSt, eggEntry);

--- a/src/EggDotNet/Format/IEggFileEntry.cs
+++ b/src/EggDotNet/Format/IEggFileEntry.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace EggDotNet.Format
+{
+	internal interface IEggFileEntry
+	{
+		int Id { get; }
+
+		string Name { get; }
+
+		uint Crc32 { get; }
+
+		bool IsEncrypted { get; }
+
+		long UncompressedSize { get; }
+
+		long CompressedSize { get;  }
+
+		CompressionMethod CompressionMethod { get; }
+
+		long Position { get; }
+
+		long ExternalAttributes { get; }
+
+#if NETSTANDARD2_1_OR_GREATER
+#nullable enable
+		DateTime? LastWriteTime { get; }
+
+		string? Comment { get; }
+#else
+		DateTime LastWriteTime { get; }
+
+		string Comment { get; }
+#endif
+
+	}
+}


### PR DESCRIPTION
`EggArchiveEntry `now pulls properties from held `IEggArchiveEntry`.  This removes need to manually re-map properties during scan.

Additional misc. cleanup.