### PR TITLE
Use Spans internally

### DIFF
--- a/src/EggDotNet/Extensions/StreamExtensions.cs
+++ b/src/EggDotNet/Extensions/StreamExtensions.cs
@@ -12,6 +12,47 @@ namespace EggDotNet.Extensions
 			return valRead > -1;
 		}
 
+#if NETSTANDARD2_1_OR_GREATER
+		public static bool ReadShort(this Stream stream, out short value)
+		{
+			Span<byte> buffer = stackalloc byte[2];
+			var fullRead = stream.Read(buffer) == 2;
+			value = BitConverter.ToInt16(buffer);
+			return fullRead;
+		}
+
+		public static bool ReadUInt(this Stream stream, out uint value)
+		{
+			Span<byte> buffer = stackalloc byte[4];
+			var fullRead = stream.Read(buffer) == 4;
+			value = BitConverter.ToUInt32(buffer);
+			return fullRead;
+		}
+
+		public static bool ReadInt(this Stream stream, out int value)
+		{
+			Span<byte> buffer = stackalloc byte[4];
+			var fullRead = stream.Read(buffer) == 4;
+			value = BitConverter.ToInt32(buffer);
+			return fullRead;
+		}
+
+		public static bool ReadLong(this Stream stream, out long value)
+		{
+			Span<byte> buffer = stackalloc byte[8];
+			var fullRead = stream.Read(buffer) == 8;
+			value = BitConverter.ToInt64(buffer);
+			return fullRead;
+		}
+#else
+		public static bool ReadShort(this Stream stream, out short value)
+		{
+			var buffer = new byte[2];
+			var fullRead = stream.Read(buffer, 0, 2) == 2;
+			value = BitConverter.ToInt16(buffer, 0);
+			return fullRead;
+		}
+
 		public static bool ReadUInt(this Stream stream, out uint value)
 		{
 			var buffer = new byte[4];
@@ -28,14 +69,6 @@ namespace EggDotNet.Extensions
 			return fullRead;
 		}
 
-		public static bool ReadShort(this Stream stream, out short value)
-		{
-			var buffer = new byte[2];
-			var fullRead = stream.Read(buffer, 0, 2) == 2;
-			value = BitConverter.ToInt16(buffer, 0);
-			return fullRead;
-		}
-
 		public static bool ReadLong(this Stream stream, out long value)
 		{
 			var buffer = new byte[8];
@@ -43,6 +76,7 @@ namespace EggDotNet.Extensions
 			value = BitConverter.ToInt64(buffer, 0);
 			return fullRead;
 		}
+#endif
 
 		public static bool ReadN(this Stream stream, int chars, out byte[] buffer)
 		{


### PR DESCRIPTION
Stream read extensions now use stackalloc Spans when reading header values. This appears to provide a small performance increase.