### PR TITLE
Trylimitreads

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ using var firstEntryStream = archive.Entries.First().Open();
 EggFile.ExtractToDirectory("archive.egg", "me/output");
 ```
 
-Pure C# and completely managed with no dependencies.  Compatible with netstandard2.0 and netstandard2.1.
+Pure, safe C# and completely managed with no dependencies.  Compatible with netstandard2.0 and netstandard2.1.
 
 ### Install using NuGet
 `Install-Package EggDotNet`

--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -43,3 +43,6 @@ Fixes and added features
 +Added EggArchiveEntry.ToString() override.
 +Added benchmark utility.
 +Misc cleanup on code.
+=======================================================================
+0.0.8-beta (2024-?)
++Refactored parsing and scanning logic to use stack allocated Spans for netstandard2.1 instead of byte[].  This appears to yield some performance improvement for netstandard2.1.

--- a/src/EggDotNet.Tests/UnitTest1.cs
+++ b/src/EggDotNet.Tests/UnitTest1.cs
@@ -48,7 +48,7 @@ namespace EggDotNet.Tests
 
 	public class UnitTest1 : IDisposable
 	{
-		private static readonly string TEST_FILES_DIR = "../../../test_files/";
+		private const string TEST_FILES_DIR = "../../../test_files/";
 
 		public static readonly Dictionary<string, TestFileInfo> TestFileInfos = new()
 		{

--- a/src/EggDotNet/EggDotNet.csproj
+++ b/src/EggDotNet/EggDotNet.csproj
@@ -18,7 +18,8 @@
 	  <AnalysisLevel>latest-recommended</AnalysisLevel>
 	  <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
 	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
-	  <PackageTags>egg, compression, alz</PackageTags>
+	  <Deterministic>true</Deterministic>
+	  <PackageTags>egg, compression, alz, deflate, lzma, bzip, alzip, altools</PackageTags>
   </PropertyGroup>
 
 	

--- a/src/EggDotNet/EggDotNet.csproj
+++ b/src/EggDotNet/EggDotNet.csproj
@@ -7,7 +7,7 @@
 	  <RepositoryUrl>https://github.com/akolman/EggDotNet</RepositoryUrl>
 	  <RepositoryType>git</RepositoryType>
 	  <Title>EggDotNet</Title>
-	  <Description>An EGG file format extraction library for DotNet.</Description>
+	  <Description>An EGG file format extraction/decompression library for DotNet.</Description>
 	  <PackageIcon>eggdotnet.png</PackageIcon>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/EggDotNet/EggDotNet.csproj
+++ b/src/EggDotNet/EggDotNet.csproj
@@ -18,7 +18,7 @@
 	  <AnalysisLevel>latest-recommended</AnalysisLevel>
 	  <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
 	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
-	  <Deterministic>true</Deterministic>
+	  <Deterministic>True</Deterministic>
 	  <PackageTags>egg, compression, alz, deflate, lzma, bzip, alzip, altools</PackageTags>
   </PropertyGroup>
 

--- a/src/EggDotNet/Extensions/ArrayExtensions.cs
+++ b/src/EggDotNet/Extensions/ArrayExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EggDotNet.Extensions
+{
+#if NETSTANDARD2_0
+	internal static class ArrayExtensions
+	{
+		public static T[] Slice<T>(this T[] buffer, int offset, int count)
+		{
+			var rtn = new T[count];
+			Array.Copy(buffer, offset, rtn, 0, count);
+			return rtn;
+		}
+	}
+#endif
+}

--- a/src/EggDotNet/Extensions/BitConverterWrapper.cs
+++ b/src/EggDotNet/Extensions/BitConverterWrapper.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EggDotNet.Extensions
+{
+#if NETSTANDARD2_0
+	internal static class BitConverterWrapper
+	{
+		public static int ToInt32(byte[] buffer)
+		{
+			return BitConverter.ToInt32(buffer, 0);
+		}
+
+		public static short ToInt16(byte[] buffer)
+		{
+			return BitConverter.ToInt16(buffer, 0);
+		}
+
+		public static uint ToUInt32(byte[] buffer)
+		{
+			return BitConverter.ToUInt32(buffer, 0);
+		}
+
+		public static long ToInt64(byte[] buffer)
+		{
+			return BitConverter.ToInt64(buffer, 0);
+		}
+	}
+#endif
+}

--- a/src/EggDotNet/Extensions/StreamExtensions.cs
+++ b/src/EggDotNet/Extensions/StreamExtensions.cs
@@ -12,6 +12,13 @@ namespace EggDotNet.Extensions
 			return valRead > -1;
 		}
 
+#if NETSTANDARD2_0
+		public static int Read(this Stream stream, byte[] buffer)
+		{
+			return stream.Read(buffer, 0, buffer.Length);
+		}
+#endif
+
 #if NETSTANDARD2_1_OR_GREATER
 		public static bool ReadShort(this Stream stream, out short value)
 		{

--- a/src/EggDotNet/Extensions/StreamExtensions.cs
+++ b/src/EggDotNet/Extensions/StreamExtensions.cs
@@ -1,98 +1,14 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace EggDotNet.Extensions
 {
+#if NETSTANDARD2_0
 	internal static class StreamExtensions
 	{
-		public static bool ReadByte(this Stream stream, out byte value)
-		{
-			var valRead = stream.ReadByte();
-			value = (byte)valRead;
-			return valRead > -1;
-		}
-
-#if NETSTANDARD2_0
 		public static int Read(this Stream stream, byte[] buffer)
 		{
 			return stream.Read(buffer, 0, buffer.Length);
 		}
-#endif
-
-#if NETSTANDARD2_1_OR_GREATER
-		public static bool ReadShort(this Stream stream, out short value)
-		{
-			Span<byte> buffer = stackalloc byte[2];
-			var fullRead = stream.Read(buffer) == 2;
-			value = BitConverter.ToInt16(buffer);
-			return fullRead;
-		}
-
-		public static bool ReadUInt(this Stream stream, out uint value)
-		{
-			Span<byte> buffer = stackalloc byte[4];
-			var fullRead = stream.Read(buffer) == 4;
-			value = BitConverter.ToUInt32(buffer);
-			return fullRead;
-		}
-
-		public static bool ReadInt(this Stream stream, out int value)
-		{
-			Span<byte> buffer = stackalloc byte[4];
-			var fullRead = stream.Read(buffer) == 4;
-			value = BitConverter.ToInt32(buffer);
-			return fullRead;
-		}
-
-		public static bool ReadLong(this Stream stream, out long value)
-		{
-			Span<byte> buffer = stackalloc byte[8];
-			var fullRead = stream.Read(buffer) == 8;
-			value = BitConverter.ToInt64(buffer);
-			return fullRead;
-		}
-#else
-		public static bool ReadShort(this Stream stream, out short value)
-		{
-			var buffer = new byte[2];
-			var fullRead = stream.Read(buffer, 0, 2) == 2;
-			value = BitConverter.ToInt16(buffer, 0);
-			return fullRead;
-		}
-
-		public static bool ReadUInt(this Stream stream, out uint value)
-		{
-			var buffer = new byte[4];
-			var fullRead = stream.Read(buffer, 0, 4) == 4;
-			value = BitConverter.ToUInt32(buffer, 0);
-			return fullRead;
-		}
-
-		public static bool ReadInt(this Stream stream, out int value)
-		{
-			var buffer = new byte[4];
-			var fullRead = stream.Read(buffer, 0, 4) == 4;
-			value = BitConverter.ToInt32(buffer, 0);
-			return fullRead;
-		}
-
-		public static bool ReadLong(this Stream stream, out long value)
-		{
-			var buffer = new byte[8];
-			var fullRead = stream.Read(buffer, 0, 8) == 8;
-			value = BitConverter.ToInt64(buffer, 0);
-			return fullRead;
-		}
-#endif
-
-		public static bool ReadN(this Stream stream, int chars, out byte[] buffer)
-		{
-			buffer = new byte[chars];
-#if NETSTANDARD2_0
-			return (stream.Read(buffer, 0, chars) == chars);
-#elif NETSTANDARD2_1_OR_GREATER
-			return (stream.Read(buffer) == chars);
-#endif
-		}
 	}
+#endif
 }

--- a/src/EggDotNet/Format/Alz/AlzEntry.cs
+++ b/src/EggDotNet/Format/Alz/AlzEntry.cs
@@ -41,20 +41,18 @@ namespace EggDotNet.Format.Alz
 
 			while (stream.ReadInt(out int nextHeader))
 			{
-				var entry = new AlzEntry();
-
 				if (nextHeader == FileHeader.ALZ_FILE_HEADER_START_MAGIC)
 				{
+					var entry = new AlzEntry();
 					entry.FileHeader = FileHeader.Parse(stream);
 					entry.Id = entries.Count;
 					stream.Seek(entry.CompressedSize, SeekOrigin.Current);
+					entries.Add(entry);
 				}
 				else if (nextHeader == FileHeader.ALZ_FILE_HEADER_END_MAGIC)
 				{
 					break;
 				}
-
-				entries.Add(entry);
 			}
 			return entries;
 		}

--- a/src/EggDotNet/Format/Alz/AlzEntry.cs
+++ b/src/EggDotNet/Format/Alz/AlzEntry.cs
@@ -7,17 +7,19 @@ namespace EggDotNet.Format.Alz
 {
 	internal sealed class AlzEntry : IEggFileEntry
 	{
+		public FileHeader FileHeader { get; private set; }
+
 		public int Id { get; private set; }
-		public string Name { get; private set; }
-		public long Position { get; private set; }
+		public string Name => FileHeader.Name;
+		public long Position => FileHeader.StartPosition;
 
-		public long UncompressedSize { get; private set; }
+		public long UncompressedSize => FileHeader.UncompressedSize;
 
-		public long CompressedSize { get; private set; }
+		public long CompressedSize => FileHeader.CompressedSize;
 
-		public uint Crc32 { get; private set; }
+		public uint Crc32 => FileHeader.Crc32;
 
-		public CompressionMethod CompressionMethod { get; private set; }
+		public CompressionMethod CompressionMethod => FileHeader.CompressionMethod;
 
 		public bool IsEncrypted => false;
 
@@ -25,13 +27,13 @@ namespace EggDotNet.Format.Alz
 
 #if NETSTANDARD2_1_OR_GREATER
 #nullable enable
-		public DateTime? LastWriteTime { get; private set; }
+		public DateTime? LastWriteTime => FileHeader.LastWriteTime;
 
-		public string? Comment => throw new NotImplementedException();
+		public string? Comment => string.Empty; //TODO
 #else
-		public DateTime LastWriteTime { get; private set; }
+		public DateTime LastWriteTime => FileHeader.LastWriteTime;
 
-		public string Comment => throw new NotImplementedException();
+		public string Comment => string.Empty; //TODO
 #endif
 		public static List<AlzEntry> ParseEntries(Stream stream)
 		{
@@ -43,22 +45,16 @@ namespace EggDotNet.Format.Alz
 
 				if (nextHeader == FileHeader.ALZ_FILE_HEADER_START_MAGIC)
 				{
-					var fileHeader = FileHeader.Parse(stream);
+					entry.FileHeader = FileHeader.Parse(stream);
 					entry.Id = entries.Count;
-					entry.CompressedSize = fileHeader.CompressedSize;
-					entry.UncompressedSize = fileHeader.UncompressedSize;
-					entry.CompressionMethod = fileHeader.CompressionMethod;
-					entry.Name = fileHeader.Name;
-					entry.Position = fileHeader.StartPosition;
-					entry.Crc32 = fileHeader.Crc32;
-					entry.LastWriteTime = fileHeader.LastWriteTime;
-					entries.Add(entry);
 					stream.Seek(entry.CompressedSize, SeekOrigin.Current);
 				}
 				else if (nextHeader == FileHeader.ALZ_FILE_HEADER_END_MAGIC)
 				{
 					break;
 				}
+
+				entries.Add(entry);
 			}
 			return entries;
 		}

--- a/src/EggDotNet/Format/Alz/AlzFormat.cs
+++ b/src/EggDotNet/Format/Alz/AlzFormat.cs
@@ -40,7 +40,7 @@ namespace EggDotNet.Format.Alz
 #pragma warning disable CA1859
 		private Stream PrepareStream()
 		{
-			return new FakeDisposingStream(_volumes.Single().GetStream());
+			return new EggStream(_volumes.Single().GetStream());
 		}
 
 		public List<EggArchiveEntry> Scan(EggArchive archive)

--- a/src/EggDotNet/Format/Alz/FileHeader.cs
+++ b/src/EggDotNet/Format/Alz/FileHeader.cs
@@ -3,6 +3,10 @@ using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 
+#if NETSTANDARD2_0
+using BitConverter = EggDotNet.Extensions.BitConverterWrapper;
+#endif
+
 namespace EggDotNet.Format.Alz
 {
 	internal sealed class FileHeader
@@ -46,32 +50,55 @@ namespace EggDotNet.Format.Alz
 		{
 			var header = new FileHeader();
 
-			stream.ReadShort(out short filenameLen);
-			stream.ReadByte(out byte attributes);
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> fileheaderBuffer = stackalloc byte[9];
+#else
+			var fileheaderBuffer = new byte[9];
+#endif
+
+			if (stream.Read(fileheaderBuffer) != 9)
+			{
+				throw new InvalidDataException("Failed reading Alz entry header");
+			}
+
+			var filenameLen = BitConverter.ToInt16(fileheaderBuffer.Slice(0, 2));
+			var attributes = fileheaderBuffer[2];
 			_ = attributes; //TODO
-			stream.ReadUInt(out uint moddate);
+			var moddate = Utilities.FromAlzTime(BitConverter.ToUInt32(fileheaderBuffer.Slice(3, 4)));
+			var bitFlags = BitConverter.ToInt16(fileheaderBuffer.Slice(7, 2));
 
-			header.LastWriteTime = Utilities.FromAlzTime(moddate);
-			//header.La = Utilities.FromAlzTime(moddate);
-			
-			//stream.Seek(5, SeekOrigin.Current);
-
-			stream.ReadShort(out short bitFlags);
 
 			if (bitFlags != 0)
 			{
-				stream.ReadShort(out short compMethodVal);
-				header.CompressionMethod = compMethodVal == 2 ? CompressionMethod.Deflate : CompressionMethod.Store;
-				stream.ReadUInt(out uint crc);
-				header.Crc32 = crc;
 				var rfs = GetReadFileSize(bitFlags);
-				stream.ReadN(rfs, out var fsBuf);
-				header.CompressedSize = ReadSize(rfs, fsBuf);
-				stream.ReadN(rfs, out fsBuf);
-				header.UncompressedSize = ReadSize(rfs, fsBuf);
+				var fileinfoBufferLen = rfs * 2 + 6;
+#if NETSTANDARD2_1_OR_GREATER
+				Span<byte> fileInfoBuffer = stackalloc byte[fileinfoBufferLen];
+#else
+				var fileInfoBuffer = new byte[fileinfoBufferLen];
+#endif
+				if (stream.Read(fileInfoBuffer) != fileinfoBufferLen)
+				{
+					throw new InvalidDataException("Failed reading Alz entry info");
+				}
+
+				var compMethodVal = BitConverter.ToInt16(fileInfoBuffer.Slice(0, 2));
+				header.CompressionMethod = compMethodVal == 2 ? CompressionMethod.Deflate : CompressionMethod.Store;
+				header.Crc32 = BitConverter.ToUInt32(fileInfoBuffer.Slice(2, 4));
+				header.CompressedSize = ReadSize(rfs, fileInfoBuffer.Slice(6, rfs));
+				header.UncompressedSize = ReadSize(rfs, fileInfoBuffer.Slice(6 + rfs, rfs));
 			}
 
-			stream.ReadN(filenameLen, out var filenameBuffer);
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> filenameBuffer = stackalloc byte[filenameLen];
+#else
+			var filenameBuffer = new byte[filenameLen];
+#endif
+
+			if (stream.Read(filenameBuffer) != filenameLen)
+			{
+				throw new InvalidDataException("Failed reading Alz entry filename");
+			}
 
 			header.Name = System.Text.Encoding.UTF8.GetString(filenameBuffer);
 			header.StartPosition = stream.Position;
@@ -86,6 +113,7 @@ namespace EggDotNet.Format.Alz
 			return (short)a;
 		}
 
+#if NETSTANDARD2_0
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private static long ReadSize(short size, byte[] buf)
 		{
@@ -94,14 +122,33 @@ namespace EggDotNet.Format.Alz
 				case 1:
 					return buf[0];
 				case 2:
-					return BitConverter.ToInt16(buf, 0);
+					return System.BitConverter.ToInt16(buf, 0);
 				case 4:
-					return BitConverter.ToInt32(buf, 0);
+					return System.BitConverter.ToInt32(buf, 0);
 				case 8:
-					return BitConverter.ToInt64(buf, 0);
+					return System.BitConverter.ToInt64(buf, 0);
 				default:
 					throw new InvalidDataException($"Invalid file size descriptor ({size})");
 			};
 		}
+#else
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private static long ReadSize(short size, Span<byte> buf)
+		{
+			switch (size)
+			{
+				case 1:
+					return buf[0];
+				case 2:
+					return BitConverter.ToInt16(buf);
+				case 4:
+					return BitConverter.ToInt32(buf);
+				case 8:
+					return BitConverter.ToInt64(buf);
+				default:
+					throw new InvalidDataException($"Invalid file size descriptor ({size})");
+			};
+		}
+#endif
 	}
 }

--- a/src/EggDotNet/Format/Alz/Header.cs
+++ b/src/EggDotNet/Format/Alz/Header.cs
@@ -5,7 +5,7 @@ namespace EggDotNet.Format.Alz
 {
 	internal sealed class Header
 	{
-		public static readonly int ALZ_HEADER_MAGIC = 0x015A4C41;
+		public const int ALZ_HEADER_MAGIC = 0x015A4C41;
 
 		public short Version { get; private set; }
 

--- a/src/EggDotNet/Format/Egg/BlockHeader.cs
+++ b/src/EggDotNet/Format/Egg/BlockHeader.cs
@@ -4,6 +4,10 @@ using System;
 using System.IO;
 using System.Linq;
 
+#if NETSTANDARD2_0
+using BitConverter = EggDotNet.Extensions.BitConverterWrapper;
+#endif
+
 namespace EggDotNet.Format.Egg
 {
 	internal sealed class BlockHeader
@@ -35,7 +39,9 @@ namespace EggDotNet.Format.Egg
 		{
 #if NETSTANDARD2_1_OR_GREATER
 			Span<byte> buffer = stackalloc byte[18];
-
+#else
+			var buffer = new byte[18];
+#endif
 			if (stream.Read(buffer) < 18)
 			{
 				throw new InvalidDataException("Failed reading block");
@@ -45,19 +51,7 @@ namespace EggDotNet.Format.Egg
 			var uncompSize = BitConverter.ToInt32(buffer.Slice(2, 4));
 			var compSize = BitConverter.ToInt32((buffer.Slice(6, 4)));
 			var crc = BitConverter.ToUInt32((buffer.Slice(10, 4)));
-#else
-			var buffer = new byte[18];
 
-			if (stream.Read(buffer, 0, 18) < 18)
-			{
-				throw new InvalidDataException("Failed reading block");
-			}
-
-			var compressionMethod = BitConverter.ToInt16(buffer.Take(2).ToArray(), 0);
-			var uncompSize = BitConverter.ToInt32(buffer.Skip(2).Take(4).ToArray(), 0);
-			var compSize = BitConverter.ToInt32(buffer.Skip(6).Take(4).ToArray(), 0);
-			var crc = BitConverter.ToUInt32(buffer.Skip(10).Take(4).ToArray(), 0);
-#endif
 			return new BlockHeader((CompressionMethod)(compressionMethod & 0xFF), compSize, uncompSize, stream.Position, crc);
 		}
 	}

--- a/src/EggDotNet/Format/Egg/CommentHeader.cs
+++ b/src/EggDotNet/Format/Egg/CommentHeader.cs
@@ -1,7 +1,5 @@
-﻿using EggDotNet.Exceptions;
-using EggDotNet.Extensions;
+﻿using EggDotNet.Extensions;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 

--- a/src/EggDotNet/Format/Egg/CommentHeader.cs
+++ b/src/EggDotNet/Format/Egg/CommentHeader.cs
@@ -3,6 +3,10 @@ using System;
 using System.IO;
 using System.Text;
 
+#if NETSTANDARD2_0
+using BitConverter = EggDotNet.Extensions.BitConverterWrapper;
+#endif
+
 namespace EggDotNet.Format.Egg
 {
 	internal sealed class CommentHeader
@@ -18,19 +22,30 @@ namespace EggDotNet.Format.Egg
 
 		public static CommentHeader Parse(Stream stream)
 		{
-			_ = stream.ReadByte();
-
-			if (!stream.ReadShort(out short size))
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> commentHeaderBuffer = stackalloc byte[3];
+#else
+			var commentHeaderBuffer = new byte[3];
+#endif
+			if (stream.Read(commentHeaderBuffer) != 3)
 			{
-				throw new InvalidDataException("Failed to read comment size");
+				throw new InvalidDataException("Failed reading comment header");
 			}
 
-			if (!stream.ReadN(size, out byte[] commentData))
+			var attributes = commentHeaderBuffer[0];
+			var commentSize = BitConverter.ToInt16(commentHeaderBuffer.Slice(1, 2));
+
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> commentDataBuffer = (commentSize < 1024) ? stackalloc byte[commentSize] : new byte[commentSize];
+#else
+			var commentDataBuffer = new byte[commentSize];
+#endif
+			if (stream.Read(commentDataBuffer) != commentSize)
 			{
 				Console.Error.WriteLine("Failed to read all contents of comment");
 			}
 
-			return new CommentHeader(Encoding.UTF8.GetString(commentData));
+			return new CommentHeader(Encoding.UTF8.GetString(commentDataBuffer));
 		}
 
 	}

--- a/src/EggDotNet/Format/Egg/EggEntry.cs
+++ b/src/EggDotNet/Format/Egg/EggEntry.cs
@@ -1,5 +1,4 @@
-﻿using EggDotNet.Extensions;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -8,34 +7,42 @@ namespace EggDotNet.Format.Egg
 {
 	internal sealed class EggEntry : IEggFileEntry
 	{
-		public int Id { get; private set; }
-		public string Name { get; private set; }
-		public long Position { get; private set; }
-
-		public long UncompressedSize { get; private set; }
-
-		public long CompressedSize { get; private set; }
-
-		public CompressionMethod CompressionMethod { get; private set; }
-
-		//public DateTime? LastModifiedTime { get; private set; }
+		public FileHeader FileHeader { get; private set; }
+		public FilenameHeader FilenameHeader { get; private set; }
 
 		public WinFileInfo WinFileInfo { get; private set; }
 
 		public EncryptHeader EncryptHeader { get; private set; }
 
-		public string Comment { get; private set; }
+		public BlockHeader BlockHeader { get; private set; }
 
-		public uint Crc32 { get; private set; }
+		public int Id => FileHeader.FileId;
+
+		public string Name => FilenameHeader.FileNameFull;
+
+		public long Position => BlockHeader.BlockDataPosition;
+
+		public long UncompressedSize => FileHeader.FileLength;
+
+		public long CompressedSize => BlockHeader.CompressedSize;
+
+		public CompressionMethod CompressionMethod => BlockHeader.CompressionMethod;
+
+		public uint Crc32 => BlockHeader.Crc32;
 
 		public bool IsEncrypted => EncryptHeader != null;
 
 		public long ExternalAttributes => GetExternalAttributes();
 
 #if NETSTANDARD2_1_OR_GREATER
+#nullable enable
 		public DateTime? LastWriteTime => GetLastWriteTime();
+
+		public string? Comment { get; private set; }
 #else
 		public DateTime LastWriteTime => GetLastWriteTime();
+
+		public string Comment { get; private set; } = string.Empty;
 #endif
 
 		public static List<EggEntry> ParseEntries(Stream stream, EggArchive archive)
@@ -61,35 +68,39 @@ namespace EggDotNet.Format.Egg
 			return entries;
 		}
 
-
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private static void BuildHeaders(EggEntry entry, EggArchive archive, Stream stream)
 		{
 			var foundEnd = false;
 			var insideFileheader = false;
-			while (!foundEnd && stream.ReadInt(out int nextHeader))
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> buff = stackalloc byte[4];
+			while (!foundEnd && stream.Read(buff) == 4)
 			{
+				var nextHeader = BitConverter.ToInt32(buff);
+#else
+			var buff = new byte[4];
+			while (!foundEnd && stream.Read(buff, 0, 4) == 4)
+			{
+				var nextHeader = BitConverter.ToInt32(buff, 0);
+#endif
 				switch (nextHeader)
 				{
 					case FileHeader.FILE_HEADER_MAGIC:
-						var fileHeader = FileHeader.Parse(stream);
-						entry.Id = fileHeader.FileId;
-						entry.UncompressedSize = fileHeader.FileLength;
+						entry.FileHeader = FileHeader.Parse(stream);
 						insideFileheader = true;
 						break;
 					case FilenameHeader.FILENAME_HEADER_MAGIC:
-						var filename = FilenameHeader.Parse(stream);
-						entry.Name = filename.FileNameFull;
+						entry.FilenameHeader = FilenameHeader.Parse(stream);
 						break;
 					case WinFileInfo.WIN_FILE_INFO_MAGIC_HEADER:
 						entry.WinFileInfo = WinFileInfo.Parse(stream);
 						break;
 					case EncryptHeader.EGG_ENCRYPT_HEADER_MAGIC:
-						var encryptHeader = EncryptHeader.Parse(stream);
-						entry.EncryptHeader = encryptHeader;
+						entry.EncryptHeader = EncryptHeader.Parse(stream);
 						break;
 					case CommentHeader.COMMENT_HEADER_MAGIC:
-						var comment = CommentHeader.Parse(stream);
+						var comment = CommentHeader.Parse(stream); //TODO: should we save CommentHeader like other members?
 						if (insideFileheader)
 							entry.Comment = comment.CommentText;
 						else
@@ -110,16 +121,20 @@ namespace EggDotNet.Format.Egg
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private static void BuildBlocks(EggEntry entry, Stream stream)
 		{
-			while (stream.ReadInt(out int nextHeader))
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> buffer = stackalloc byte[4];
+			while (stream.Read(buffer) == 4)
 			{
+				var nextHeader = BitConverter.ToInt32(buffer);
+#else
+			var buffer = new byte[4];
+			while (stream.Read(buffer, 0, 4) == 4)
+			{
+				var nextHeader = BitConverter.ToInt32(buffer, 0);
+#endif
 				if (nextHeader == BlockHeader.BLOCK_HEADER_MAGIC)
 				{
-					var blockHeader = BlockHeader.Parse(stream);
-					entry.Position = blockHeader.BlockDataPosition;
-					entry.CompressedSize = blockHeader.CompressedSize;
-					//entry.UncompressedSize = blockHeader.UncompressedSize; //set by file header
-					entry.CompressionMethod = blockHeader.CompressionMethod;
-					entry.Crc32 = blockHeader.Crc32;
+					entry.BlockHeader = BlockHeader.Parse(stream);
 					stream.Seek(entry.CompressedSize, SeekOrigin.Current);
 					break;
 				}

--- a/src/EggDotNet/Format/Egg/EggFormat.cs
+++ b/src/EggDotNet/Format/Egg/EggFormat.cs
@@ -92,7 +92,7 @@ namespace EggDotNet.Format.Egg
 
 			if (_volumes.Count == 1)
 			{
-				return new FakeDisposingStream(_volumes.Single().GetStream());
+				return new EggStream(_volumes.Single().GetStream());
 			}
 			else
 			{
@@ -100,7 +100,7 @@ namespace EggDotNet.Format.Egg
 			}
 		}
 
-		private CollectiveStream PrepareSplitStream()
+		private CollectiveEggStream PrepareSplitStream()
 		{
 			var subStreams = new List<SubStream>(_volumes.Count);
 			var curVol = _volumes.Single(v => v.Header.SplitHeader.PreviousFileId == 0);
@@ -114,7 +114,7 @@ namespace EggDotNet.Format.Egg
 				subStreams.Add(new SubStream(curSt, curVol.Header.HeaderEndPosition));
 			}
 
-			return new CollectiveStream(subStreams);
+			return new CollectiveEggStream(subStreams);
 		}
 
 		private Stream GetDecryptionStream(Stream subSt, EggEntry eggEntry)

--- a/src/EggDotNet/Format/Egg/FileHeader.cs
+++ b/src/EggDotNet/Format/Egg/FileHeader.cs
@@ -1,8 +1,10 @@
-﻿using EggDotNet.Exceptions;
-using EggDotNet.Extensions;
+﻿using EggDotNet.Extensions;
 using System;
 using System.IO;
-using System.Linq;
+
+#if NETSTANDARD2_0
+using BitConverter = EggDotNet.Extensions.BitConverterWrapper;
+#endif
 
 namespace EggDotNet.Format.Egg
 {
@@ -26,6 +28,9 @@ namespace EggDotNet.Format.Egg
 		{
 #if NETSTANDARD2_1_OR_GREATER
 			Span<byte> headerBuffer = stackalloc byte[12];
+#else
+			var headerBuffer = new byte[12];
+#endif
 			if (stream.Read(headerBuffer) != 12)
 			{
 				throw new InvalidDataException("Failed reading file entry header");
@@ -33,16 +38,6 @@ namespace EggDotNet.Format.Egg
 
 			var fileId = BitConverter.ToInt32(headerBuffer.Slice(0, 4));
 			var fileLength = BitConverter.ToInt64(headerBuffer.Slice(4, 8));
-#else
-			var headerBuffer = new byte[12];
-			if (stream.Read(headerBuffer, 0, 12) != 12)
-			{
-				throw new InvalidDataException("Failed reading file entry header");
-			}
-
-			var fileId = BitConverter.ToInt32(headerBuffer.Take(4).ToArray(), 0);
-			var fileLength = BitConverter.ToInt64(headerBuffer.Skip(4).Take(8).ToArray(), 0);
-#endif
 
 			return new FileHeader(fileId, fileLength);
 		}

--- a/src/EggDotNet/Format/Egg/FilenameHeader.cs
+++ b/src/EggDotNet/Format/Egg/FilenameHeader.cs
@@ -34,28 +34,39 @@ namespace EggDotNet.Format.Egg
 		public static FilenameHeader Parse(Stream stream)
 		{
 			var nameEncoder = Encoding.UTF8;
-
-			var bitFlagByte = stream.ReadByte();
-			if (bitFlagByte == -1)
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> filenameHeaderBuffer = stackalloc byte[3];
+#else
+			var filenameHeaderBuffer = new byte[3];
+#endif
+			if (stream.Read(filenameHeaderBuffer) != 3)
 			{
-				throw new InvalidDataException("Filename header flag couldn't be read");
+				throw new InvalidDataException("Failed reading filename header");
 			}
 
-			var bitFlag = (FilenameFlags)bitFlagByte;
+			var bitFlag = (FilenameFlags)filenameHeaderBuffer[0];
 
 			if (bitFlag.HasFlag(FilenameFlags.Encrypt))
 			{
 				throw new InvalidDataException("Encrypted filenames not supported");
 			}
 
-			if (!stream.ReadShort(out short filenameSize))
-			{
-				throw new InvalidDataException("Filename size couldn't be read");
-			}
+			var filenameSize = BitConverter.ToInt16(filenameHeaderBuffer.Slice(1, 2));
 
 			if (bitFlag.HasFlag(FilenameFlags.UseAreaCode))
 			{
-				stream.ReadShort(out short locale);
+#if NETSTANDARD2_1_OR_GREATER
+				Span<byte> localeBuffer = stackalloc byte[2];
+#else
+				var localeBuffer = new byte[2];
+#endif
+				if (stream.Read(localeBuffer) != 2)
+				{
+					throw new InvalidDataException("Failed reading filename locale");
+				}
+
+				var locale = BitConverter.ToInt16(localeBuffer);
+
 				try
 				{
 					nameEncoder = Encoding.GetEncoding(locale);

--- a/src/EggDotNet/Format/Egg/FilenameHeader.cs
+++ b/src/EggDotNet/Format/Egg/FilenameHeader.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
+#if NETSTANDARD2_0
+using BitConverter = EggDotNet.Extensions.BitConverterWrapper;
+#endif
+
 namespace EggDotNet.Format.Egg
 {
 	internal sealed class FilenameHeader //: ExtraField2
@@ -64,21 +68,15 @@ namespace EggDotNet.Format.Egg
 
 #if NETSTANDARD2_1_OR_GREATER
 			Span<byte> filenameBytes = stackalloc byte[filenameSize];
+#else
+			var filenameBytes = new byte[filenameSize];
+#endif
 			if (stream.Read(filenameBytes) != filenameSize)
 			{
 				throw new InvalidDataException("Filename header corrupt");
 			}
 
 			return new FilenameHeader(nameEncoder.GetString(filenameBytes));
-#else
-			var filenameBytes = new byte[filenameSize];
-			if (stream.Read(filenameBytes, 0, filenameSize) != filenameSize)
-			{
-				throw new InvalidDataException("Filename header corrupt");
-			}
-
-			return new FilenameHeader(nameEncoder.GetString(filenameBytes));
-#endif
 		}
 	}
 }

--- a/src/EggDotNet/Format/Egg/FilenameHeader.cs
+++ b/src/EggDotNet/Format/Egg/FilenameHeader.cs
@@ -62,12 +62,23 @@ namespace EggDotNet.Format.Egg
 				}
 			}
 
-			if (!stream.ReadN(filenameSize, out byte[] filenameBuffer))
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> filenameBytes = stackalloc byte[filenameSize];
+			if (stream.Read(filenameBytes) != filenameSize)
 			{
 				throw new InvalidDataException("Filename header corrupt");
 			}
 
-			return new FilenameHeader(nameEncoder.GetString(filenameBuffer));
+			return new FilenameHeader(nameEncoder.GetString(filenameBytes));
+#else
+			var filenameBytes = new byte[filenameSize];
+			if (stream.Read(filenameBytes, 0, filenameSize) != filenameSize)
+			{
+				throw new InvalidDataException("Filename header corrupt");
+			}
+
+			return new FilenameHeader(nameEncoder.GetString(filenameBytes));
+#endif
 		}
 	}
 }

--- a/src/EggDotNet/Format/Egg/Header.cs
+++ b/src/EggDotNet/Format/Egg/Header.cs
@@ -10,9 +10,9 @@ namespace EggDotNet.Format.Egg
 	/// </summary>
 	internal sealed class Header
 	{
-		private static readonly short HEADER_SIZE_BYTES = 14;
+		private const short HEADER_SIZE_BYTES = 14;
 
-		public static readonly int EGG_HEADER_MAGIC = 0x41474745;
+		public const int EGG_HEADER_MAGIC = 0x41474745;
 
 		public const int EGG_HEADER_END_MAGIC = 0x08E28222;
 

--- a/src/EggDotNet/Format/Egg/SolidHeader.cs
+++ b/src/EggDotNet/Format/Egg/SolidHeader.cs
@@ -10,8 +10,16 @@ namespace EggDotNet.Format.Egg
 
 		public static SolidHeader Parse(Stream stream)
 		{
-			_ = stream.ReadByte();
-			stream.ReadShort(out short _);
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> buffer = stackalloc byte[3];
+#else
+			var buffer = new byte[3];
+#endif
+			if (stream.Read(buffer) != 3)
+			{
+				throw new InvalidDataException("Failed reading solid header");
+			}
+
 			Console.Error.WriteLine("SOLID compression not implemented.  May encounter errors.");
 
 			return new SolidHeader();

--- a/src/EggDotNet/Format/Egg/SplitHeader.cs
+++ b/src/EggDotNet/Format/Egg/SplitHeader.cs
@@ -1,7 +1,10 @@
 ﻿using EggDotNet.Extensions;
 using System;
 using System.IO;
-using System.Linq;
+
+#if NETSTANDARD2_0
+using BitConverter = EggDotNet.Extensions.BitConverterWrapper;
+#endif
 
 namespace EggDotNet.Format.Egg
 {
@@ -23,6 +26,9 @@ namespace EggDotNet.Format.Egg
 		{
 #if NETSTANDARD2_1_OR_GREATER
 			Span<byte> buffer = stackalloc byte[11];
+#else
+			var buffer = new byte[11];
+#endif
 			if (stream.Read(buffer) < 11)
 			{
 				throw new InvalidDataException("Failed reading split header");
@@ -30,16 +36,6 @@ namespace EggDotNet.Format.Egg
 
 			var prevFileId = BitConverter.ToInt32(buffer.Slice(3, 4));
 			var nextFileId = BitConverter.ToInt32(buffer.Slice(7, 4));
-#else
-			var buffer = new byte[11];
-			if (stream.Read(buffer, 0, 11) < 11)
-			{
-				throw new InvalidDataException("Failed reading split header");
-			}
-
-			var prevFileId = BitConverter.ToInt32(buffer.Skip(3).Take(4).ToArray(), 0);
-			var nextFileId = BitConverter.ToInt32(buffer.Skip(7).Take(4).ToArray(), 0);
-#endif
 
 			return new SplitHeader(prevFileId, nextFileId);
 		}

--- a/src/EggDotNet/Format/Egg/WinFileInfo.cs
+++ b/src/EggDotNet/Format/Egg/WinFileInfo.cs
@@ -1,6 +1,7 @@
 ﻿using EggDotNet.Extensions;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace EggDotNet.Format.Egg
 {
@@ -14,17 +15,25 @@ namespace EggDotNet.Format.Egg
 
 		public static WinFileInfo Parse(Stream stream)
 		{
-			_ = stream.ReadByte();
-
-			_ = stream.ReadShort(out short _);
-
-			if (!stream.ReadLong(out long lastModTime))
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> winFileBuffer = stackalloc byte[12];
+			if (stream.Read(winFileBuffer) != 12)
 			{
-
+				throw new InvalidDataException("Failed reading windows file header");
 			}
 
-			var attributes = stream.ReadByte();
+			var lastModTime = BitConverter.ToInt64(winFileBuffer.Slice(3, 8));
+			var attributes = winFileBuffer[11];
+#else
+			var winFileBuffer = new byte[12];
+			if (stream.Read(winFileBuffer, 0, 12) != 12)
+			{
+				throw new InvalidDataException("Failed reading windows file header");
+			}
 
+			var lastModTime = BitConverter.ToInt64(winFileBuffer.Skip(3).Take(8).ToArray(), 0);
+			var attributes = winFileBuffer[11];
+#endif
 			return new WinFileInfo() { LastModified = Utilities.FromEggTime(lastModTime), WindowsFileAttributes = attributes };
 		}
 	}

--- a/src/EggDotNet/Format/Egg/WinFileInfo.cs
+++ b/src/EggDotNet/Format/Egg/WinFileInfo.cs
@@ -1,7 +1,10 @@
 ﻿using EggDotNet.Extensions;
 using System;
 using System.IO;
-using System.Linq;
+
+#if NETSTANDARD2_0
+using BitConverter = EggDotNet.Extensions.BitConverterWrapper;
+#endif
 
 namespace EggDotNet.Format.Egg
 {
@@ -17,6 +20,9 @@ namespace EggDotNet.Format.Egg
 		{
 #if NETSTANDARD2_1_OR_GREATER
 			Span<byte> winFileBuffer = stackalloc byte[12];
+#else
+			var winFileBuffer = new byte[12];
+#endif
 			if (stream.Read(winFileBuffer) != 12)
 			{
 				throw new InvalidDataException("Failed reading windows file header");
@@ -24,16 +30,7 @@ namespace EggDotNet.Format.Egg
 
 			var lastModTime = BitConverter.ToInt64(winFileBuffer.Slice(3, 8));
 			var attributes = winFileBuffer[11];
-#else
-			var winFileBuffer = new byte[12];
-			if (stream.Read(winFileBuffer, 0, 12) != 12)
-			{
-				throw new InvalidDataException("Failed reading windows file header");
-			}
 
-			var lastModTime = BitConverter.ToInt64(winFileBuffer.Skip(3).Take(8).ToArray(), 0);
-			var attributes = winFileBuffer[11];
-#endif
 			return new WinFileInfo() { LastModified = Utilities.FromEggTime(lastModTime), WindowsFileAttributes = attributes };
 		}
 	}

--- a/src/EggDotNet/Format/Global.cs
+++ b/src/EggDotNet/Format/Global.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EggDotNet.Format
+{
+	internal static class Global
+	{
+		public const short HEADER_SIZE = 4;
+	}
+}

--- a/src/EggDotNet/GlobalSuppressions.cs
+++ b/src/EggDotNet/GlobalSuppressions.cs
@@ -9,3 +9,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0074:Use compound assignment", Justification = "No netstandard2.0 support")]
 [assembly: SuppressMessage("Style", "IDE0063", Justification = "No netstandard2.0 support")]
 [assembly: SuppressMessage("Style", "IDE0066", Justification = "No netstandard2.0 support")]
+[assembly: SuppressMessage("Style", "IDE0057:Use range operator", Justification = "Breaks netstandard2.0 byte[] polyfills")]

--- a/src/EggDotNet/SpecialStreams/CollectiveEggStream.cs
+++ b/src/EggDotNet/SpecialStreams/CollectiveEggStream.cs
@@ -7,7 +7,7 @@ namespace EggDotNet.SpecialStreams
 {
 #pragma warning disable CA2215
 
-	internal sealed class CollectiveStream : Stream
+	internal sealed class CollectiveEggStream : Stream
 	{
 		private readonly List<SubStream> subStreams;
 		private readonly long totalLength;
@@ -33,7 +33,7 @@ namespace EggDotNet.SpecialStreams
 			}
 		}
 
-		public CollectiveStream(List<Stream> streams)
+		public CollectiveEggStream(List<Stream> streams)
 		{
 			var posTemps = new List<long>(streams.Count);
 			subStreams = new List<SubStream>(streams.Count);
@@ -54,7 +54,7 @@ namespace EggDotNet.SpecialStreams
 
 		}
 
-		public CollectiveStream(List<SubStream> streams)
+		public CollectiveEggStream(List<SubStream> streams)
 		{
 			var posTemps = new List<long>(streams.Count);
 			var len = 0L;

--- a/src/EggDotNet/SpecialStreams/EggStream.cs
+++ b/src/EggDotNet/SpecialStreams/EggStream.cs
@@ -3,7 +3,7 @@
 #pragma warning disable CA2213, CA2215
 namespace EggDotNet.SpecialStreams
 {
-	internal sealed class FakeDisposingStream : Stream
+	internal sealed class EggStream : Stream
 	{
 		private readonly Stream _stream;
 
@@ -17,7 +17,7 @@ namespace EggDotNet.SpecialStreams
 
 		public override long Position { get => _stream.Position; set => _stream.Position = value; }
 
-		public FakeDisposingStream(Stream stream)
+		public EggStream(Stream stream)
 		{
 			_stream = stream;
 		}


### PR DESCRIPTION
Refactored parsing and scanning logic to use stack allocated Spans for netstandard2.1 instead of byte[].  This appears to yield some performance improvement for netstandard2.1. deterministic build