### PR TITLE
0.3.0dev

### DIFF
--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -72,3 +72,11 @@ Fixes and added features
 +Added EggArchiveEntry.ExtractToStream method.
 +Added additional testing.  Code coverage now above 80%.
 +Fixed issue prevent EggFile extraction when entry was in a directory.
+=======================================================================
+0.3.0-beta (2026-04-1?)
++Added HMAC verification for AES and LEA decryption.
++Added validation to EggArchiveEntry to prevent directory traversal.
++Added attempted support for dummy header.  Unable to create file so unable to test.
++Misc. disposal and internal cleanup.
++Added lea test.
+-Removed EggArchiveEntry.ExternalAttributes obsoleted in 0.2.0-beta.

--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -73,10 +73,11 @@ Fixes and added features
 +Added additional testing.  Code coverage now above 80%.
 +Fixed issue prevent EggFile extraction when entry was in a directory.
 =======================================================================
-0.3.0-beta (2026-04-1?)
+0.3.0-beta (2026-04-13)
 +Added HMAC verification for AES and LEA decryption.
 +Added validation to EggArchiveEntry to prevent directory traversal.
 +Added attempted support for dummy header.  Unable to create file so unable to test.
 +Misc. disposal and internal cleanup.
 +Added lea test.
++Added additional header validation.
 -Removed EggArchiveEntry.ExternalAttributes obsoleted in 0.2.0-beta.

--- a/src/EggDotNet.Samples/ExtractToDirectory/EggDotNet.Samples.ExtractToDirectory.csproj
+++ b/src/EggDotNet.Samples/ExtractToDirectory/EggDotNet.Samples.ExtractToDirectory.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EggDotNet" Version="0.2.0" />
+    <PackageReference Include="EggDotNet" Version="0.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/EggDotNet.Samples/ViewPosixInfo/EggDotNet.Samples.ViewPosixInfo.csproj
+++ b/src/EggDotNet.Samples/ViewPosixInfo/EggDotNet.Samples.ViewPosixInfo.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EggDotNet" Version="0.2.0" />
+    <PackageReference Include="EggDotNet" Version="0.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/EggDotNet.Tests/EggDotNet.Tests.csproj
+++ b/src/EggDotNet.Tests/EggDotNet.Tests.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-	  <OutputType>Exe</OutputType>
+	<OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EggDotNet.Tests/UnitTest1.cs
+++ b/src/EggDotNet.Tests/UnitTest1.cs
@@ -431,9 +431,22 @@ namespace EggDotNet.Tests
 		}
 
 		[Fact]
-		public void Test_Decrypt_Fails_With_Exception()
+		public void Test_Decrypt_aes_Fails_With_Exception()
 		{
 			using var fs = new FileStream(GetTestPath("lorem_long_aes256.egg"), FileMode.Open, FileAccess.Read);
+			using var archive = new EggArchive(fs, false, null, (filename, options) => { options.Password = "badpassword"; options.Retry = false; });
+			var ent = archive.Entries.First();
+			Assert.True(ent.IsEncrypted);
+			Assert.ThrowsAny<DecryptFailedException>(() =>
+			{
+				using var entSt = ent.Open();
+			});
+		}
+
+		[Fact]
+		public void Test_Decrypt_lea_Fails_With_Exception()
+		{
+			using var fs = new FileStream(GetTestPath("lorem_long_store_lea128.egg"), FileMode.Open, FileAccess.Read);
 			using var archive = new EggArchive(fs, false, null, (filename, options) => { options.Password = "badpassword"; options.Retry = false; });
 			var ent = archive.Entries.First();
 			Assert.True(ent.IsEncrypted);

--- a/src/EggDotNet/Callbacks.cs
+++ b/src/EggDotNet/Callbacks.cs
@@ -25,7 +25,6 @@ namespace EggDotNet
 
 			internal PasswordCallbackOptions()
 			{
-
 			}
 		}
 

--- a/src/EggDotNet/Compression/DeflateCompressionProvider.cs
+++ b/src/EggDotNet/Compression/DeflateCompressionProvider.cs
@@ -1,5 +1,5 @@
-﻿using System.IO.Compression;
-using System.IO;
+﻿using System.IO;
+using System.IO.Compression;
 
 namespace EggDotNet.Compression
 {

--- a/src/EggDotNet/Compression/IStreamCompressionProvider.cs
+++ b/src/EggDotNet/Compression/IStreamCompressionProvider.cs
@@ -1,5 +1,4 @@
-﻿using EggDotNet.SpecialStreams;
-using System.IO;
+﻿using System.IO;
 
 namespace EggDotNet.Compression
 {

--- a/src/EggDotNet/EggArchive.cs
+++ b/src/EggDotNet/EggArchive.cs
@@ -1,11 +1,11 @@
 ﻿using EggDotNet.Format;
+using EggDotNet.Format.Egg;
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using static EggDotNet.Callbacks;
-using EggDotNet.Format.Egg;
 
 
 #if NETSTANDARD2_1_OR_GREATER

--- a/src/EggDotNet/EggArchiveEntry.cs
+++ b/src/EggDotNet/EggArchiveEntry.cs
@@ -91,15 +91,6 @@ namespace EggDotNet
 #endif
 
 		/// <summary>
-		/// Gets the external attributes for the entry.
-		/// </summary>
-		/// <remarks>See <see cref="WindowsFileAttributes"/>.
-		/// For entries which contain Windows file attributes, the value will be the lowest 4 bytes of the total long value.
-		/// </remarks>
-		[Obsolete("Use GetExtraAttributes method")]
-		public long ExternalAttributes => entry.ExternalAttributes;
-
-		/// <summary>
 		/// Gets the comment of the file.
 		/// </summary>
 		public string Comment => entry.Comment ?? string.Empty;

--- a/src/EggDotNet/EggDotNet.csproj
+++ b/src/EggDotNet/EggDotNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-	  <Version>0.2.0</Version>
+	  <Version>0.3.0</Version>
 	  <Authors>Andrew Kolman</Authors>
 	  <RepositoryUrl>https://github.com/akolman/EggDotNet</RepositoryUrl>
 	  <RepositoryType>git</RepositoryType>

--- a/src/EggDotNet/EggFile.cs
+++ b/src/EggDotNet/EggFile.cs
@@ -43,7 +43,7 @@ namespace EggDotNet
 		}
 
 		/// <summary>
-		/// 
+		/// Extracts an EGG archive from a source Stream to a destination directory, calling the provided callbacks upon start and completion of each entry.
 		/// </summary>
 		/// <param name="sourceStream">The source EGG stream.</param>
 		/// <param name="destinationDirectory">The desination directory path to place files.</param>

--- a/src/EggDotNet/Encryption/Aes/CryptoMode.cs
+++ b/src/EggDotNet/Encryption/Aes/CryptoMode.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace EggDotNet.Encryption.Aes
+﻿namespace EggDotNet.Encryption.Aes
 {
 	internal enum CryptoMode
 	{

--- a/src/EggDotNet/Encryption/Aes/EggAesCipherStream.cs
+++ b/src/EggDotNet/Encryption/Aes/EggAesCipherStream.cs
@@ -31,10 +31,12 @@ namespace EggDotNet.Encryption.Aes
 		private readonly byte[] _PendingWriteBlock;
 		private int _pendingCount;
 		private readonly byte[] _iobuf;
+		private readonly byte[] _expectedMac;
 
-		internal EggAesCipherStream(System.IO.Stream s, EggAesCrypto cryptoParams, long length, CryptoMode mode)
+		internal EggAesCipherStream(System.IO.Stream s, EggAesCrypto cryptoParams, long length, CryptoMode mode, byte[] expectedMac = null)
 			: base()
 		{
+			_expectedMac = expectedMac;
 			_params = cryptoParams;
 			_s = s;
 			_mode = mode;
@@ -202,6 +204,21 @@ namespace EggDotNet.Encryption.Aes
 			ReadTransformBlocks(buffer, offset, bytesToRead);
 
 			_totalBytesXferred += n;
+
+			if (_finalBlock && _expectedMac != null)
+			{
+				var computed = FinalAuthentication;
+				if (computed.Length != _expectedMac.Length)
+					throw new System.IO.InvalidDataException("The MAC does not match.");
+
+				int diff = 0;
+				for (int i = 0; i < computed.Length; i++)
+					diff |= computed[i] ^ _expectedMac[i];
+
+				if (diff != 0)
+					throw new System.IO.InvalidDataException("The MAC does not match.");
+			}
+
 			return n;
 		}
 
@@ -322,9 +339,5 @@ namespace EggDotNet.Encryption.Aes
 		{
 			throw new NotImplementedException();
 		}
-
-#pragma warning disable IDE0052 // Remove unread private members
-		private readonly object _outputLock = new Object();
-#pragma warning restore IDE0052 // Remove unread private members
 	}
 }

--- a/src/EggDotNet/Encryption/Aes/EggAesCrypto.cs
+++ b/src/EggDotNet/Encryption/Aes/EggAesCrypto.cs
@@ -1,45 +1,45 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 
-#pragma warning disable
+#pragma warning disable CA5379
 
 namespace EggDotNet.Encryption.Aes
 {
 	[ExcludeFromCodeCoverage]
-	internal class EggAesCrypto
+	internal sealed class EggAesCrypto
 	{
+		private const int Rfc2898KeygenIterations = 1000;
+
 		internal byte[] _Salt;
 		internal byte[] _providedPv;
 		internal byte[] _generatedPv;
 		internal int _KeyStrengthInBits;
 		private byte[] _MacInitializationVector;
-		private byte[] _StoredMac;
 		private byte[] _keyBytes;
-		private Int16 PasswordVerificationStored;
-		private Int16 PasswordVerificationGenerated;
-		private const int Rfc2898KeygenIterations = 1000;
-		private string _Password;
+		private short PasswordVerificationStored;
+		private short PasswordVerificationGenerated;
+		private readonly string _Password;
 		private bool _cryptoGenerated;
 
-		private EggAesCrypto(string password, int KeyStrengthInBits)
+		private EggAesCrypto(string password, int keyStrengthInBits)
 		{
 			_Password = password;
-			_KeyStrengthInBits = KeyStrengthInBits;
+			_KeyStrengthInBits = keyStrengthInBits;
 		}
 
-		public static EggAesCrypto ReadFromStream(string password, int KeyStrengthInBits, byte[] salt, byte[] pwV)
+		public static EggAesCrypto ReadFromStream(string password, int keyStrengthInBits, byte[] salt, byte[] pwV)
 		{
-			EggAesCrypto c = new EggAesCrypto(password, KeyStrengthInBits)
+			var c = new EggAesCrypto(password, keyStrengthInBits)
 			{
 				_Salt = salt,
 				_providedPv = pwV
 			};
 
-			c.PasswordVerificationStored = (Int16)(c._providedPv[0] + c._providedPv[1] * KeyStrengthInBits);
+			c.PasswordVerificationStored = (short)(c._providedPv[0] + c._providedPv[1] * keyStrengthInBits);
 
 			if (password != null)
 			{
-				c.PasswordVerificationGenerated = (Int16)(c.GeneratedPV[0] + c.GeneratedPV[1] * KeyStrengthInBits);
+				c.PasswordVerificationGenerated = (short)(c.GeneratedPV[0] + c.GeneratedPV[1] * keyStrengthInBits);
 			}
 
 			return c;
@@ -56,61 +56,7 @@ namespace EggDotNet.Encryption.Aes
 			}
 		}
 
-		public byte[] Salt
-		{
-			get
-			{
-				return _Salt;
-			}
-		}
-
-		private int _KeyStrengthInBytes
-		{
-			get
-			{
-				return _KeyStrengthInBits / 8;
-
-			}
-		}
-
-		public int SizeOfEncryptionMetadata
-		{
-			get
-			{
-				// 10 bytes after, (n-10) before the compressed data
-				return _KeyStrengthInBytes / 2 + 10 + 2;
-			}
-		}
-
-		public string Password
-		{
-			set
-			{
-				_Password = value;
-				if (_Password != null)
-				{
-					PasswordVerificationGenerated = (Int16)(GeneratedPV[0] + GeneratedPV[1] * 256);
-					if (PasswordVerificationGenerated != PasswordVerificationStored)
-						throw new System.Exception();
-				}
-			}
-			private get
-			{
-				return _Password;
-			}
-		}
-
-		private void _GenerateCryptoBytes()
-		{
-			System.Security.Cryptography.Rfc2898DeriveBytes rfc2898 =
-				new System.Security.Cryptography.Rfc2898DeriveBytes(_Password, Salt, Rfc2898KeygenIterations);
-
-			_keyBytes = rfc2898.GetBytes(_KeyStrengthInBytes); // 16 or 24 or 32 ???
-			_MacInitializationVector = rfc2898.GetBytes(_KeyStrengthInBytes);
-			_generatedPv = rfc2898.GetBytes(2);
-
-			_cryptoGenerated = true;
-		}
+		public byte[] Salt => _Salt;
 
 		public byte[] KeyBytes
 		{
@@ -130,34 +76,20 @@ namespace EggDotNet.Encryption.Aes
 			}
 		}
 
-		public byte[] CalculatedMac;
+		public int SizeOfEncryptionMetadata => _KeyStrengthInBytes / 2 + 10 + 2;
 
-		public void ReadAndVerifyMac(System.IO.Stream s)
+		private int _KeyStrengthInBytes => _KeyStrengthInBits / 8;
+
+		private void _GenerateCryptoBytes()
 		{
-			bool invalid = false;
-
-			// read integrityCheckVector.
-			// caller must ensure that the file pointer is in the right spot!
-			_StoredMac = new byte[10];  // aka "authentication code"
-			s.Read(_StoredMac, 0, _StoredMac.Length);
-
-			if (_StoredMac.Length != CalculatedMac.Length)
-				invalid = true;
-
-			if (!invalid)
+			using (var rfc2898 = new System.Security.Cryptography.Rfc2898DeriveBytes(_Password, Salt, Rfc2898KeygenIterations))
 			{
-				for (int i = 0; i < _StoredMac.Length; i++)
-				{
-					if (_StoredMac[i] != CalculatedMac[i])
-						invalid = true;
-				}
+				_keyBytes = rfc2898.GetBytes(_KeyStrengthInBytes);
+				_MacInitializationVector = rfc2898.GetBytes(_KeyStrengthInBytes);
+				_generatedPv = rfc2898.GetBytes(2);
 			}
 
-			if (invalid)
-				throw new System.Exception("The MAC does not match.");
+			_cryptoGenerated = true;
 		}
-
 	}
-
-
 }

--- a/src/EggDotNet/Encryption/AesStreamDecryptionProvider.cs
+++ b/src/EggDotNet/Encryption/AesStreamDecryptionProvider.cs
@@ -1,21 +1,16 @@
 ﻿using EggDotNet.Encryption.Aes;
-using System;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-
-#pragma warning disable 
 
 namespace EggDotNet.Encryption
 {
-	internal class AesStreamDecryptionProvider : IStreamDecryptionProvider
+	internal sealed class AesStreamDecryptionProvider : IStreamDecryptionProvider
 	{
-#pragma warning disable IDE0052 // Remove unread private members
 		private readonly byte[] _footer;
-#pragma warning restore IDE0052 // Remove unread private members
-		private int _bits;
-		private byte[] _header;
+		private readonly int _bits;
+		private readonly byte[] _header;
 		private EggAesCrypto _crypto;
+
 		public AesStreamDecryptionProvider(int bits, byte[] header, byte[] footer)
 		{
 			_footer = footer;
@@ -36,16 +31,13 @@ namespace EggDotNet.Encryption
 				_crypto = EggAesCrypto.ReadFromStream(password, _bits, _header.Take(8).ToArray(), _header.Skip(8).Take(2).ToArray());
 			}
 
-			return _crypto.PasswordValid;	
+			return _crypto.PasswordValid;
 		}
 
 		public Stream GetDecryptionStream(Stream stream)
 		{
 			stream.Seek(0, SeekOrigin.Begin);
-
-			var decrypt = new EggAesCipherStream(stream, _crypto, stream.Length, CryptoMode.Decrypt);
-
-			return decrypt;
+			return new EggAesCipherStream(stream, _crypto, stream.Length, CryptoMode.Decrypt, _footer);
 		}
 	}
 }

--- a/src/EggDotNet/Encryption/Lea/Imp/CTRModeLeaTransformer.cs
+++ b/src/EggDotNet/Encryption/Lea/Imp/CTRModeLeaTransformer.cs
@@ -19,7 +19,6 @@ namespace EggDotNet.Encryption.Lea.Imp
 			Array.Copy(_iv, _ctr, BLOCK_SIZE_BYTES);
 		}
 
-
 		public override int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
 		{
 			var len = base.TransformBlock(_ctr, 0, inputCount, _block, 0);

--- a/src/EggDotNet/Encryption/Lea/Imp/Lea.cs
+++ b/src/EggDotNet/Encryption/Lea/Imp/Lea.cs
@@ -11,6 +11,7 @@ namespace EggDotNet.Encryption.Lea.Imp
 		private byte[] _salt;
 		private byte[] _keyBytes;
 		private byte[] _MacInitializationVector;
+		private byte[] _macKey;
 		private byte[] _generatedPv;
 		private byte[] _storedPv;
 
@@ -42,6 +43,8 @@ namespace EggDotNet.Encryption.Lea.Imp
 
 		public bool PasswordValid => Enumerable.SequenceEqual(_generatedPv, _storedPv);
 
+		public byte[] MacKey => _macKey;
+
 		public override int KeySize { get; set; }
 
 		public override CipherMode Mode { get; set; }
@@ -51,14 +54,16 @@ namespace EggDotNet.Encryption.Lea.Imp
 			_salt = salt.Take(keySizeBits == 256 ? 16 : 8).ToArray();
 
 #pragma warning disable CA5379
-			var rfc2898 = new Rfc2898DeriveBytes(password, _salt, 1000);
+			using (var rfc2898 = new Rfc2898DeriveBytes(password, _salt, 1000))
+			{
+				_keyBytes = rfc2898.GetBytes(keySizeBits / 8); // 16 or 24 or 32 ???
+				_macKey = rfc2898.GetBytes(keySizeBits == 256 ? 32 : 16);
+				_MacInitializationVector = _macKey.Take(keySizeBits == 256 ? 16 : 8).ToArray();
+				_generatedPv = rfc2898.GetBytes(2);
+			}
 #pragma warning restore CA5379
 
-			_keyBytes = rfc2898.GetBytes(keySizeBits / 8); // 16 or 24 or 32 ???
-			_MacInitializationVector = rfc2898.GetBytes(keySizeBits == 256 ? 32 : 16).Take(keySizeBits == 256 ? 16 : 8).ToArray();
-			_generatedPv = rfc2898.GetBytes(2);
 			_storedPv = salt.Skip(keySizeBits == 256 ? 16 : 8).Take(2).ToArray();
-			//_cryptoGenerated = true;
 		}
 
 		public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
@@ -89,19 +94,21 @@ namespace EggDotNet.Encryption.Lea.Imp
 				if (!disposed)
 				{
 					Array.Clear(_salt, 0, _salt.Length);
-					Array.Clear(_MacInitializationVector,0 , _MacInitializationVector.Length);
+					Array.Clear(_MacInitializationVector, 0, _MacInitializationVector.Length);
 					Array.Clear(_keyBytes, 0, _keyBytes.Length);
+					Array.Clear(_macKey, 0, _macKey.Length);
 					Array.Clear(_generatedPv, 0, _generatedPv.Length);
 					Array.Clear(_storedPv, 0, _storedPv.Length);
 
 					_salt = null;
 					_MacInitializationVector = null;
 					_keyBytes = null;
+					_macKey = null;
 					_generatedPv = null;
 					_storedPv = null;
 				}
 
-				disposed = false;
+				disposed = true;
 			}
 		}
 	}

--- a/src/EggDotNet/Encryption/Lea/LeaStream.cs
+++ b/src/EggDotNet/Encryption/Lea/LeaStream.cs
@@ -3,47 +3,54 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 
+#pragma warning disable CA5350, CS0414
+
 namespace EggDotNet.Encryption.Lea
 {
 	internal sealed class LeaStream : Stream
 	{
-		private bool _disposed;
-
-		public override bool CanRead => true;
-
-		public override bool CanSeek => false;
-
-		public override bool CanWrite => false;
-
-		public override long Length => throw new NotImplementedException();
-
-		public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
 		private Stream _stream;
 		private ICryptoTransform _crypto;
+		private HMACSHA1 _mac;
+		private readonly byte[] _expectedMac;
+		private bool _disposed;
+		private bool _finalBlock;
 
-		public LeaStream(Stream stream, ICryptoTransform cryptoTransform)
+		public LeaStream(Stream stream, ICryptoTransform cryptoTransform, byte[] macIv = null, byte[] expectedMac = null)
 		{
 			_stream = stream;
 			_crypto = cryptoTransform;
+			_expectedMac = expectedMac;
+			if (macIv != null)
+			{
+				_mac = new HMACSHA1(macIv);
+			}
 		}
 
-		public override void Flush()
-		{
-			throw new NotImplementedException();
-		}
+		public override bool CanRead => true;
+		public override bool CanSeek => false;
+		public override bool CanWrite => false;
+		public override long Length => throw new NotSupportedException();
+		public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
 
 		public override int Read(byte[] buffer, int offset, int count)
 		{
+			if (_finalBlock)
+				return 0;
+
 			var readBuf = new byte[count];
 			var readLen = _stream.Read(readBuf, offset, count);
 			if (readLen <= LeaCryptoTransform.BLOCK_SIZE_BYTES)
 			{
+				_mac?.TransformFinalBlock(readBuf, 0, readLen);
 				_crypto.TransformFinalBlock(buffer, 0, readLen);
+				_finalBlock = true;
+				VerifyMac();
 			}
 			else
 			{
-				for(var i=0; i <= count - LeaCryptoTransform.BLOCK_SIZE_BYTES; i+= LeaCryptoTransform.BLOCK_SIZE_BYTES)
+				_mac?.TransformBlock(readBuf, 0, readLen, null, 0);
+				for (var i = 0; i <= count - LeaCryptoTransform.BLOCK_SIZE_BYTES; i += LeaCryptoTransform.BLOCK_SIZE_BYTES)
 				{
 					_crypto.TransformBlock(readBuf, i, readLen, buffer, i);
 				}
@@ -51,37 +58,44 @@ namespace EggDotNet.Encryption.Lea
 			return readLen;
 		}
 
-		public override long Seek(long offset, SeekOrigin origin)
-		{
-			throw new NotImplementedException();
-		}
-
-		public override void SetLength(long value)
-		{
-			throw new NotImplementedException();
-		}
-
-		public override void Write(byte[] buffer, int offset, int count)
-		{
-			throw new NotImplementedException();
-		}
+		public override void Flush() => throw new NotSupportedException();
+		public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+		public override void SetLength(long value) => throw new NotSupportedException();
+		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
 #pragma warning disable CA2215
 		protected override void Dispose(bool disposing)
 #pragma warning restore CA2215
 		{
-			if (disposing)
+			if (disposing && !_disposed)
 			{
-				if (!_disposed)
-				{
-					_stream.Dispose();
-					_crypto.Dispose();
-					_stream = null;
-					_crypto = null;
-				}
+				_stream.Dispose();
+				_crypto.Dispose();
+				_mac?.Dispose();
+				_stream = null;
+				_crypto = null;
+				_mac = null;
 				_disposed = true;
 			}
-			//base.Dispose(); //don't call this
+		}
+
+		private void VerifyMac()
+		{
+			if (_mac == null || _expectedMac == null)
+				return;
+
+			var computed = new byte[10];
+			Array.Copy(_mac.Hash, 0, computed, 0, 10);
+
+			if (computed.Length != _expectedMac.Length)
+				throw new InvalidDataException("The MAC does not match.");
+
+			int diff = 0;
+			for (int i = 0; i < computed.Length; i++)
+				diff |= computed[i] ^ _expectedMac[i];
+
+			if (diff != 0)
+				throw new InvalidDataException("The MAC does not match.");
 		}
 	}
 }

--- a/src/EggDotNet/Encryption/LeaStreamDecryptionProvider.cs
+++ b/src/EggDotNet/Encryption/LeaStreamDecryptionProvider.cs
@@ -1,20 +1,16 @@
 ﻿using EggDotNet.Encryption.Lea;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
 
 namespace EggDotNet.Encryption
 {
 	internal sealed class LeaStreamDecryptionProvider : IStreamDecryptionProvider
 	{
-#pragma warning disable IDE0052 // Remove unread private members
 		private readonly byte[] _footer;
-#pragma warning restore IDE0052 // Remove unread private members
 		private readonly int _bits;
 		private readonly byte[] _header;
-		ICryptoTransform _cryptoTransform;
+		private ICryptoTransform _cryptoTransform;
+		private byte[] _macIv;
 
 		public LeaStreamDecryptionProvider(int bits, byte[] header, byte[] footer)
 		{
@@ -30,6 +26,7 @@ namespace EggDotNet.Encryption
 				if (lea.PasswordValid)
 				{
 					_cryptoTransform = lea.CreateDecryptor(lea.Key, new byte[16]);
+					_macIv = (byte[])lea.MacKey.Clone();
 					return true;
 				}
 				return false;
@@ -38,8 +35,7 @@ namespace EggDotNet.Encryption
 
 		public Stream GetDecryptionStream(Stream stream)
 		{
-			var st = new LeaStream(stream, _cryptoTransform);
-			return st;
+			return new LeaStream(stream, _cryptoTransform, _macIv, _footer);
 		}
 	}
 }

--- a/src/EggDotNet/Encryption/ZipStreamDecryptionProvider.cs
+++ b/src/EggDotNet/Encryption/ZipStreamDecryptionProvider.cs
@@ -37,7 +37,5 @@ namespace EggDotNet.Encryption
 			_decrypt.AttachStream(stream);
 			return _decrypt;
 		}
-
-
 	}
 }

--- a/src/EggDotNet/EncryptionMethod.cs
+++ b/src/EggDotNet/EncryptionMethod.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// Represents the encryption method used to encrypt an entry.
 	/// </summary>
-	public enum EncryptionMethod : byte
+	internal enum EncryptionMethod : byte
 	{
 		/// <summary>
 		/// Standard Zip2.0 encryption.

--- a/src/EggDotNet/Extensions/EggArchiveEntryExtensions.cs
+++ b/src/EggDotNet/Extensions/EggArchiveEntryExtensions.cs
@@ -14,6 +14,7 @@ namespace EggDotNet.Extensions
 		/// </summary>
 		/// <param name="entry">The source entry.</param>
 		/// <param name="destinationDirectory">The destination directory to extract the entry into.</param>
+		/// <exception cref="IOException">Thrown when the entry path would escape the destination directory.</exception>
 		public static void ExtractToDirectory(this EggArchiveEntry entry, string destinationDirectory)
 		{
 			using (var entryStream = entry.Open())
@@ -30,6 +31,14 @@ namespace EggDotNet.Extensions
 				Directory.CreateDirectory(destinationDirectory);
 
 				var path = Path.Combine(destinationDirectory, entryName);
+				
+				/*path traversal check*/
+				var fullDestination = Path.GetFullPath(destinationDirectory);
+				var fullPath = Path.GetFullPath(path);
+				if (!fullPath.StartsWith(fullDestination, StringComparison.Ordinal))
+				{
+					throw new IOException($"Entry path escapes the destination directory: {entry.FullName}");
+				}
 
 				using (var foStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
 				{

--- a/src/EggDotNet/Format/Alz/AlzEntry.cs
+++ b/src/EggDotNet/Format/Alz/AlzEntry.cs
@@ -35,9 +35,6 @@ namespace EggDotNet.Format.Alz
 
 		public override bool IsEncrypted => false;
 
-		[Obsolete("Use GetExtraAttributes method")]
-		public override long ExternalAttributes => 0;
-
 #if NETSTANDARD2_1_OR_GREATER
 #nullable enable
 		public override DateTime? LastWriteTime => FileHeader.LastWriteTime;

--- a/src/EggDotNet/Format/Alz/FileHeader.cs
+++ b/src/EggDotNet/Format/Alz/FileHeader.cs
@@ -62,7 +62,7 @@ namespace EggDotNet.Format.Alz
 			}
 
 			var filenameLen = BitConverter.ToInt16(fileheaderBuffer.Slice(0, 2));
-			if (filenameLen < 0)
+			if (filenameLen < 0 || filenameLen > 2 << 7)
 			{
 				throw new InvalidDataException("Invalid filename length");
 			}

--- a/src/EggDotNet/Format/Alz/FileHeader.cs
+++ b/src/EggDotNet/Format/Alz/FileHeader.cs
@@ -62,6 +62,11 @@ namespace EggDotNet.Format.Alz
 			}
 
 			var filenameLen = BitConverter.ToInt16(fileheaderBuffer.Slice(0, 2));
+			if (filenameLen < 0)
+			{
+				throw new InvalidDataException("Invalid filename length");
+			}
+
 			var attributes = fileheaderBuffer[2];
 			_ = attributes; //TODO
 			var moddate = DateUtilities.FromAlzTime(BitConverter.ToUInt32(fileheaderBuffer.Slice(3, 4)));

--- a/src/EggDotNet/Format/Egg/DummyHeader.cs
+++ b/src/EggDotNet/Format/Egg/DummyHeader.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Diagnostics.CodeAnalysis;
+
+#if NETSTANDARD2_0
+using BitConverter = EggDotNet.InternalExtensions.BitConverterWrapper;
+using EggDotNet.InternalExtensions;
+#endif
+
+namespace EggDotNet.Format.Egg
+{
+	[ExcludeFromCodeCoverage]
+	internal sealed class DummyHeader
+	{
+		public const int DUMMY_HEADER_MAGIC = 0x07463307;
+
+		private readonly short _size;
+
+		private DummyHeader(short size)
+		{
+			_size = size;
+		}
+
+		public static DummyHeader Parse(Stream stream)
+		{
+#if NETSTANDARD2_1_OR_GREATER
+			Span<byte> dummyHeader = stackalloc byte[3];
+#else
+			var dummyHeader = new byte[3];
+#endif
+			if (stream.Read(dummyHeader) != 3)
+			{
+				throw new InvalidDataException("Failed reading dummy header");
+			}
+
+			var dummySize = BitConverter.ToInt16(dummyHeader.Slice(1, 2));
+			stream.Seek(dummySize, SeekOrigin.Current);
+			return new DummyHeader(dummySize);
+		}
+	}
+}

--- a/src/EggDotNet/Format/Egg/EggEntry.cs
+++ b/src/EggDotNet/Format/Egg/EggEntry.cs
@@ -175,6 +175,9 @@ namespace EggDotNet.Format.Egg
 						else
 							archive.Comment = comment.CommentText;
 						break;
+					case DummyHeader.DUMMY_HEADER_MAGIC:
+						_ = DummyHeader.Parse(stream);
+						break;
 					case FileHeader.FILE_END_HEADER:
 						foundEnd = true;
 						break;

--- a/src/EggDotNet/Format/Egg/EggEntry.cs
+++ b/src/EggDotNet/Format/Egg/EggEntry.cs
@@ -45,9 +45,6 @@ namespace EggDotNet.Format.Egg
 
 		public override bool IsEncrypted => EncryptHeader != null;
 
-		[Obsolete("Use GetExtraAttributes method")]
-		public override long ExternalAttributes => GetFileAttributes();
-
 #if NETSTANDARD2_1_OR_GREATER
 #nullable enable
 		public override DateTime? LastWriteTime => GetLastWriteTime();

--- a/src/EggDotNet/Format/Egg/EggFormat.cs
+++ b/src/EggDotNet/Format/Egg/EggFormat.cs
@@ -122,9 +122,8 @@ namespace EggDotNet.Format.Egg
 					var extVolume = EggVolume.Parse(extStream, ownStream);
 					tempVolumes.Add(extVolume);
 				}
-				catch(Exception e)
+				catch
 				{
-					_ = e; /*volume was not an egg archive*/
 					if (ownStream) extStream.Dispose();
 				}
 			}
@@ -240,7 +239,6 @@ namespace EggDotNet.Format.Egg
 					break;
 				default:
 					throw new UnknownCompressionException((byte)entry.CompressionMethod);
-
 			}
 
 			return compressor.GetDecompressStream(stream);

--- a/src/EggDotNet/Format/Egg/EncryptHeader.cs
+++ b/src/EggDotNet/Format/Egg/EncryptHeader.cs
@@ -52,6 +52,10 @@ namespace EggDotNet.Format.Egg
 			}
 
 			var size = BitConverter.ToInt16(encryptHeaderBuffer.Slice(1, 2));
+			if (size > 2 << 7)
+			{
+				throw new InvalidDataException("Invalid encryption buffer length");
+			}
 
 #if NETSTANDARD2_1_OR_GREATER
 			Span<byte> encDataBuffer = stackalloc byte[size];

--- a/src/EggDotNet/Format/Egg/EncryptHeader.cs
+++ b/src/EggDotNet/Format/Egg/EncryptHeader.cs
@@ -8,7 +8,7 @@ using BitConverter = EggDotNet.InternalExtensions.BitConverterWrapper;
 
 namespace EggDotNet.Format.Egg
 {
-    internal sealed class EncryptHeader
+	internal sealed class EncryptHeader
 	{
 		public const int EGG_ENCRYPT_HEADER_MAGIC = 0x08D1470F;
 
@@ -36,7 +36,6 @@ namespace EggDotNet.Format.Egg
 			Param2 = aesFooter;
 		}
 #endif
-
 
 		public static EncryptHeader Parse(Stream stream)
 		{

--- a/src/EggDotNet/Format/Egg/FilenameHeader.cs
+++ b/src/EggDotNet/Format/Egg/FilenameHeader.cs
@@ -52,6 +52,10 @@ namespace EggDotNet.Format.Egg
 			}
 
 			var filenameSize = BitConverter.ToInt16(filenameHeaderBuffer.Slice(1, 2));
+			if (filenameSize > 2 << 7) /*protect from stack blowout*/
+			{
+				throw new InvalidDataException("Invalid filename size");
+			}
 
 			if (bitFlag.HasFlag(FilenameFlags.UseAreaCode))
 			{

--- a/src/EggDotNet/Format/EggFileEntryBase.cs
+++ b/src/EggDotNet/Format/EggFileEntryBase.cs
@@ -20,9 +20,6 @@ namespace EggDotNet.Format
 
 		public abstract long Position { get; }
 
-		[Obsolete("Use GetExtraAttributes method")]
-		public abstract long ExternalAttributes { get; }
-
 #if NETSTANDARD2_1_OR_GREATER
 #nullable enable
 		public abstract DateTime? LastWriteTime { get; }


### PR DESCRIPTION
+Added HMAC verification for AES and LEA decryption.
+Added validation to EggArchiveEntry to prevent directory traversal.
+Added attempted support for dummy header.  Unable to create file so unable to test.
+Misc. disposal and internal cleanup.
+Added lea test.
+Added additional header validation.
-Removed EggArchiveEntry.ExternalAttributes obsoleted in 0.2.0-beta.

Closes #36 